### PR TITLE
# use dateTime instead of timestamp. Timestamp would not allow post_d…

### DIFF
--- a/src/migrations/2016_05_19_000000_create_accounting_journal_transactions_table.php
+++ b/src/migrations/2016_05_19_000000_create_accounting_journal_transactions_table.php
@@ -29,8 +29,8 @@ class CreateAccountingJournalTransactionsTable extends Migration
 	        $table->text('memo')->nullable();
 	        $table->char('ref_class',32)->nullable();
 	        $table->integer('ref_class_id')->nullable();
-	        $table->timestamp('post_date');
             $table->timestamps();
+            $table->dateTime('post_date');
             $table->softDeletes();
         });
     }


### PR DESCRIPTION
The default behavior now is, post_date can never be set at debit/credit call.  Also, since post_date is declared first in the migration script, it gets the AUTO UPDATED behaviour. (http://dev.mysql.com/doc/refman/5.5/en/timestamp-initialization.html)