### PR TITLE
Fix  'Currencies must be identical' bug

### DIFF
--- a/src/migrations/2016_05_19_000000_create_accounting_journals_table.php
+++ b/src/migrations/2016_05_19_000000_create_accounting_journals_table.php
@@ -24,8 +24,8 @@ class CreateAccountingJournalsTable extends Migration
             $table->increments('id');
             $table->unsignedInteger('ledger_id')->nullable();
             $table->bigInteger('balance');
-            $table->char('currency',5);
-	        $table->char('morphed_type',32);
+            $table->string('currency',5);
+	        $table->string('morphed_type',32);
 	        $table->integer('morphed_id');
             $table->timestamps();
         });


### PR DESCRIPTION
This will fix InvalidArgumentException with message 'Currencies must be identical', because of  'USD  '  !== 'USD'